### PR TITLE
Add Connection ClientSetting

### DIFF
--- a/client_option.go
+++ b/client_option.go
@@ -24,6 +24,7 @@ type ClientSettings struct {
 	Scopes      []string
 	CallOptions map[string][]CallOption
 	DialOptions []grpc.DialOption
+	Connection  *grpc.ClientConn
 }
 
 func (w ClientSettings) Resolve(s *ClientSettings) {
@@ -33,6 +34,7 @@ func (w ClientSettings) Resolve(s *ClientSettings) {
 	WithScopes(w.Scopes...).Resolve(s)
 	WithCallOptions(w.CallOptions).Resolve(s)
 	WithDialOptions(w.DialOptions...).Resolve(s)
+	s.Connection = w.Connection
 }
 
 type withAppName string
@@ -96,4 +98,14 @@ func (w withDialOptions) Resolve(s *ClientSettings) {
 
 func WithDialOptions(opts ...grpc.DialOption) ClientOption {
 	return withDialOptions(opts)
+}
+
+type withConnection grpc.ClientConn
+
+func (w *withConnection) Resolve(s *ClientSettings) {
+	s.Connection = (*grpc.ClientConn)(w)
+}
+
+func WithConnection(conn *grpc.ClientConn) ClientOption {
+	return (*withConnection)(conn)
 }

--- a/client_option_test.go
+++ b/client_option_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestClientOptionsPieceByPiece(t *testing.T) {
+	conn := &grpc.ClientConn{}
 	expected := &ClientSettings{
 		"myapi",
 		"v0.1.0",
@@ -16,6 +17,7 @@ func TestClientOptionsPieceByPiece(t *testing.T) {
 		[]string{"https://example.com/auth/helloworld", "https://example.com/auth/otherthing"},
 		map[string][]CallOption{"ListWorlds": []CallOption{WithTimeout(3 * time.Second)}},
 		[]grpc.DialOption{},
+		conn,
 	}
 
 	settings := &ClientSettings{}
@@ -26,6 +28,7 @@ func TestClientOptionsPieceByPiece(t *testing.T) {
 		WithScopes("https://example.com/auth/helloworld", "https://example.com/auth/otherthing"),
 		WithCallOptions(map[string][]CallOption{"ListWorlds": []CallOption{WithTimeout(3 * time.Second)}}),
 		WithDialOptions(), // Can't compare function signatures for equality.
+		WithConnection(conn),
 	}
 	clientOptions(opts).Resolve(settings)
 

--- a/dial.go
+++ b/dial.go
@@ -14,6 +14,9 @@ func DialGRPC(ctx context.Context, opts ...ClientOption) (*grpc.ClientConn, erro
 	settings := &ClientSettings{}
 	clientOptions(opts).Resolve(settings)
 
+	if settings.Connection != nil {
+		return settings.Connection, nil
+	}
 	var dialOpts = settings.DialOptions
 	if len(dialOpts) == 0 {
 		tokenSource, err := google.DefaultTokenSource(ctx, settings.Scopes...)


### PR DESCRIPTION
On Dial, if Connection is not nil, it's used in place of any user
provided gRPC settings or the default.