### PR TITLE
Make README more helpful

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,17 @@ Google API Extensions for Go (gax-go) is a set of modules which aids the
 development of APIs for clients and servers based on `gRPC` and Google API
 conventions.
 
-This project is currently experimental and not supported.
+Application code will rarely need to use this library directly,
+but the code generated automatically from API definition files can use it
+to simplify code generation and to provide more convenient and idiomatic API surface.
+
+**This project is currently experimental and not supported.**
+
+Go Versions
+===========
+This library requires Go 1.6 or above.
+
+License
+=======
+BSD - please see [LICENSE](https://github.com/googleapis/gax-go/blob/master/LICENSE)
+for more information.

--- a/gax.go
+++ b/gax.go
@@ -30,9 +30,9 @@
 // Package gax contains a set of modules which aid the development of APIs
 // for clients and servers based on gRPC and Google API conventions.
 //
-// Application code will rarely need to use this library directly,
-// but the code generated automatically from API definition files can use it
-// to simplify code generation and to provide more convenient and idiomatic API surface.
+// Application code will rarely need to use this library directly.
+// However, code generated automatically from API definition files can use it
+// to simplify code generation and to provide more convenient and idiomatic API surfaces.
 //
 // This project is currently experimental and not supported.
 package gax

--- a/gax.go
+++ b/gax.go
@@ -27,6 +27,14 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+// Package gax contains a set of modules which aid the development of APIs
+// for clients and servers based on gRPC and Google API conventions.
+//
+// Application code will rarely need to use this library directly,
+// but the code generated automatically from API definition files can use it
+// to simplify code generation and to provide more convenient and idiomatic API surface.
+//
+// This project is currently experimental and not supported.
 package gax
 
 const Version = "0.1.0"


### PR DESCRIPTION
Make clear that end users will rarely use this library directly.

Add license information and required Go version to README.

Fixes #38.