### PR TITLE
add gRPC call options

### DIFF
--- a/call_option.go
+++ b/call_option.go
@@ -129,8 +129,21 @@ func (bo *Backoff) Pause() time.Duration {
 	return d
 }
 
+type grpcOpt []grpc.CallOption
+
+func (o grpcOpt) Resolve(s *CallSettings) {
+	s.GRPC = o
+}
+
+func WithGRPCOptions(opt ...grpc.CallOption) CallOption {
+	return grpcOpt(append([]grpc.CallOption(nil), opt...))
+}
+
 type CallSettings struct {
 	// Retry returns a Retryer to be used to control retry logic of a method call.
 	// If Retry is nil or the returned Retryer is nil, the call will not be retried.
 	Retry func() Retryer
+
+	// CallOption to be forwarded to GRPC.
+	GRPC []grpc.CallOption
 }

--- a/call_option.go
+++ b/call_option.go
@@ -144,6 +144,6 @@ type CallSettings struct {
 	// If Retry is nil or the returned Retryer is nil, the call will not be retried.
 	Retry func() Retryer
 
-	// CallOption to be forwarded to GRPC.
+	// CallOptions to be forwarded to GRPC.
 	GRPC []grpc.CallOption
 }

--- a/invoke.go
+++ b/invoke.go
@@ -36,7 +36,7 @@ import (
 )
 
 // A user defined call stub.
-type APICall func(context.Context) error
+type APICall func(context.Context, CallSettings) error
 
 // Invoke calls the given APICall,
 // performing retries as specified by opts, if any.
@@ -67,7 +67,7 @@ type sleeper func(ctx context.Context, d time.Duration) error
 func invoke(ctx context.Context, call APICall, settings CallSettings, sp sleeper) error {
 	var retryer Retryer
 	for {
-		err := call(ctx)
+		err := call(ctx, settings)
 		if err == nil {
 			return nil
 		}

--- a/invoke_test.go
+++ b/invoke_test.go
@@ -58,7 +58,7 @@ type boolRetryer bool
 func (r boolRetryer) Retry(err error) (time.Duration, bool) { return 0, bool(r) }
 
 func TestInvokeSuccess(t *testing.T) {
-	apiCall := func(_ context.Context) error { return nil }
+	apiCall := func(context.Context, CallSettings) error { return nil }
 	var sp recordSleeper
 	err := invoke(context.Background(), apiCall, CallSettings{}, sp.sleep)
 
@@ -72,7 +72,7 @@ func TestInvokeSuccess(t *testing.T) {
 
 func TestInvokeNoRetry(t *testing.T) {
 	apiErr := errors.New("foo error")
-	apiCall := func(_ context.Context) error { return apiErr }
+	apiCall := func(context.Context, CallSettings) error { return apiErr }
 	var sp recordSleeper
 	err := invoke(context.Background(), apiCall, CallSettings{}, sp.sleep)
 
@@ -86,7 +86,7 @@ func TestInvokeNoRetry(t *testing.T) {
 
 func TestInvokeNilRetry(t *testing.T) {
 	apiErr := errors.New("foo error")
-	apiCall := func(_ context.Context) error { return apiErr }
+	apiCall := func(context.Context, CallSettings) error { return apiErr }
 	var settings CallSettings
 	WithRetry(func() Retryer { return nil }).Resolve(&settings)
 	var sp recordSleeper
@@ -102,7 +102,7 @@ func TestInvokeNilRetry(t *testing.T) {
 
 func TestInvokeNeverRetry(t *testing.T) {
 	apiErr := errors.New("foo error")
-	apiCall := func(_ context.Context) error { return apiErr }
+	apiCall := func(context.Context, CallSettings) error { return apiErr }
 	var settings CallSettings
 	WithRetry(func() Retryer { return boolRetryer(false) }).Resolve(&settings)
 	var sp recordSleeper
@@ -121,7 +121,7 @@ func TestInvokeRetry(t *testing.T) {
 
 	retryNum := 0
 	apiErr := errors.New("foo error")
-	apiCall := func(context.Context) error {
+	apiCall := func(context.Context, CallSettings) error {
 		retryNum++
 		if retryNum < target {
 			return apiErr
@@ -143,7 +143,7 @@ func TestInvokeRetry(t *testing.T) {
 
 func TestInvokeRetryTimeout(t *testing.T) {
 	apiErr := errors.New("foo error")
-	apiCall := func(context.Context) error { return apiErr }
+	apiCall := func(context.Context, CallSettings) error { return apiErr }
 	var settings CallSettings
 	WithRetry(func() Retryer { return boolRetryer(true) }).Resolve(&settings)
 	var sp recordSleeper


### PR DESCRIPTION
This contains a breaking change that should not affect end users.
The APICall signature now also accepts a CallSettings struct.