### PR TITLE
document stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Application code will rarely need to use this library directly,
 but the code generated automatically from API definition files can use it
 to simplify code generation and to provide more convenient and idiomatic API surface.
 
-**This project is currently experimental and not supported.**
-
 Go Versions
 ===========
 This library requires Go 1.6 or above.

--- a/gax.go
+++ b/gax.go
@@ -33,8 +33,6 @@
 // Application code will rarely need to use this library directly.
 // However, code generated automatically from API definition files can use it
 // to simplify code generation and to provide more convenient and idiomatic API surfaces.
-//
-// This project is currently experimental and not supported.
 package gax
 
-const Version = "0.1.0"
+const Version = "2.0.0"


### PR DESCRIPTION
gax has been tagged stable (v2.0.0) more than 6 months ago.
We seem to have forgotten to update the reported version and readme :(.