### PR TITLE
travis: remove unnecessary scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ language: go
 go:
   - 1.6
   - 1.7
-before_install:
-  - go get golang.org/x/tools/cmd/cover
-  - go get golang.org/x/tools/cmd/goimports
 script:
   - gofmt -l .
-  - goimports -l .
   - go tool vet .
   - go test -coverprofile=coverage.txt -covermode=atomic
 after_success:


### PR DESCRIPTION
- No need to install cover tool; it is already a part of go tool itself.
- No need to install goimports; it depends on "context" and makes go1.6
  fail on CI

Also @jadekler