### PR TITLE
backoff starts at 1 instead of zero

### DIFF
--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -126,10 +126,11 @@ func (bo *Backoff) Pause() time.Duration {
 	if bo.Multiplier < 1 {
 		bo.Multiplier = 2
 	}
-	// Select a duration between zero and the current max. It might seem counterintuitive to
-	// have so much jitter, but https://www.awsarchitectureblog.com/2015/03/backoff.html
-	// argues that that is the best strategy.
-	d := time.Duration(rand.Int63n(int64(bo.cur)))
+	// Select a duration between 1ns and the current max. It might seem
+	// counterintuitive to have so much jitter, but
+	// https://www.awsarchitectureblog.com/2015/03/backoff.html argues that
+	// that is the best strategy.
+	d := time.Duration(1 + rand.Int63n(int64(bo.cur)))
 	bo.cur = time.Duration(float64(bo.cur) * bo.Multiplier)
 	if bo.cur > bo.Max {
 		bo.cur = bo.Max


### PR DESCRIPTION
NewTicker(time.Duration(0)) is illegal - let's prevent it from being able to
happen.