### PR TITLE
fix kokoro path

### DIFF
--- a/internal/kokoro/test.sh
+++ b/internal/kokoro/test.sh
@@ -9,7 +9,7 @@ set -eo pipefail
 set -x
 
 # cd to project dir on Kokoro instance
-cd git/gax-go
+cd github/gax-go
 
 go version
 


### PR DESCRIPTION
Taking a stab in the dark as to where the repository is located, based on
https://github.com/googleapis/google-cloud-java/blob/940999d7a50b1d006b5869c1bcd1eea7aaec4c71/.kokoro/common.cfg#L12