### PR TITLE
switch to modules for CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/googleapis/gax-go
 
 require (
+	github.com/golang/protobuf v1.2.0
 	github.com/googleapis/gax-go/v2 v2.0.2
+	golang.org/x/exp v0.0.0-20190123073158-f1c91bc264ca
+	golang.org/x/lint v0.0.0-20180702182130-06c8688daad7
+	golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52
 	google.golang.org/grpc v1.16.0
+	honnef.co/go/tools v0.0.0-20180728063816-88497007e858
 )

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,11 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/googleapis/gax-go/v2 v2.0.2 h1:/rNgUniLy2vDXiK2xyJOcirGpC3G99dtK1NWx26WZ8Y=
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
+github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+golang.org/x/exp v0.0.0-20190123073158-f1c91bc264ca h1:AFNsZPKS1Cu5aMtVA2TZW38aYAz5ANRg38HTtVPHK/I=
+golang.org/x/exp v0.0.0-20190123073158-f1c91bc264ca/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/lint v0.0.0-20180702182130-06c8688daad7 h1:00BeQWmeaGazuOrq8Q5K5d3/cHaGuFrZzpaHBXfrsUA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPFgVGd+z1DZwjfRu4d0I=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -19,10 +23,12 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52 h1:JG/0uqcGdTNgq7FdU+61l5Pdmb8putNZlXb65bJBROs=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.16.0 h1:dz5IJGuC2BB7qXR5AyHNwAUBhZscK2xVez7mznh72sY=
 google.golang.org/grpc v1.16.0/go.mod h1:0JHn/cJsOMiMfNA9+DeHDlAU7KAAB5GDlYFpa9MZMio=
+honnef.co/go/tools v0.0.0-20180728063816-88497007e858 h1:wN+eVZ7U+gqdqkec6C6VXR1OFf9a5Ul9ETzeYsYv20g=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/kokoro/check_incompat_changes.sh
+++ b/internal/kokoro/check_incompat_changes.sh
@@ -10,10 +10,6 @@ if [[ `go version` != *"go1.11"* ]]; then
     exit 0
 fi
 
-try3() { eval "$*" || eval "$*" || eval "$*"; }
-
-try3 go get -u golang.org/x/exp/cmd/apidiff
-
 # We compare against master@HEAD. This is unfortunate in some cases: if you're
 # working on an out-of-date branch, and master gets some new feature (that has
 # nothing to do with your work on your branch), you'll get an error message.

--- a/internal/kokoro/vet.sh
+++ b/internal/kokoro/vet.sh
@@ -14,18 +14,13 @@ fi
 
 pwd
 
+export GO111MODULE=on
+
 # Fail if a dependency was added without the necessary go.mod/go.sum change
 # being part of the commit.
-GO111MODULE=on go mod tidy
+go mod tidy
 git diff go.mod | tee /dev/stderr | (! read)
 git diff go.sum | tee /dev/stderr | (! read)
-
-try3() { eval "$*" || eval "$*" || eval "$*"; }
-
-try3 go get -u \
-  golang.org/x/lint/golint \
-  golang.org/x/tools/cmd/goimports \
-  honnef.co/go/tools/cmd/staticcheck
 
 # Look at all .go files (ignoring .pb.go files) and make sure they have a Copyright. Fail if any don't.
 git ls-files "*[^.pb].go" | xargs grep -L "\(Copyright [0-9]\{4,\}\)" 2>&1 | tee /dev/stderr | (! read)

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,0 +1,32 @@
+// +build tools
+
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package exists to cause `go mod` and `go get` to believe these tools
+// are dependencies, even though they are not runtime dependencies of any
+// package (these are tools used by our CI builds). This means they will appear
+// in our `go.mod` file, but will not be a part of the build. Also, since the
+// build target is something non-existent, these should not be included in any
+// binaries.
+
+package internal
+
+import (
+	_ "github.com/golang/protobuf/protoc-gen-go"
+	_ "golang.org/x/exp/cmd/apidiff"
+	_ "golang.org/x/lint/golint"
+	_ "golang.org/x/tools/cmd/goimports"
+	_ "honnef.co/go/tools/cmd/staticcheck"
+)


### PR DESCRIPTION
Previously, go get would download the latest version of each dependency since
v1.11 is in the transitionary modules/GOPATH state and lacks GO111MODULE=on.
Now, let's turn GO111MODULE=on for all commands and download just the go.mod
deps. (also, does so individually for v1 and v2 since they have different
go.mod files)