### PR TITLE
gax: update protobuf-golang plugin to 1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/googleapis/gax-go
 
 require (
-	github.com/golang/protobuf v1.2.0
+	github.com/golang/protobuf v1.3.1
 	github.com/googleapis/gax-go/v2 v2.0.2
 	golang.org/x/exp v0.0.0-20190221220918-438050ddec5e
 	golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,5 +1,3 @@
 module github.com/googleapis/gax-go/v2
 
-go 1.12
-
 require google.golang.org/grpc v1.19.0


### PR DESCRIPTION
Relevant context: https://github.com/google/go-genproto/pull/164

Also removes unnecessary (and troublesome) go1.12 line in v2/.