### PR TITLE
better docs around Backoff

### DIFF
--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -94,22 +94,25 @@ func (r *boRetryer) Retry(err error) (time.Duration, bool) {
 	return 0, false
 }
 
-// Backoff implements exponential backoff.
-// The wait time between retries is a random value between 0 and the "retry envelope".
-// The envelope starts at Initial and increases by the factor of Multiplier every retry,
-// but is capped at Max.
+// Backoff implements exponential backoff. The wait time between retries is a
+// random value between 0 and the "retry period" - the time between retries. The
+// retry period starts at Initial and increases by the factor of Multiplier
+// every retry, but is capped at Max.
+//
+// Note: MaxNumRetries / RPCDeadline is specifically not provided. These should
+// be built on top of Backoff.
 type Backoff struct {
-	// Initial is the initial value of the retry envelope, defaults to 1 second.
+	// Initial is the initial value of the retry period, defaults to 1 second.
 	Initial time.Duration
 
-	// Max is the maximum value of the retry envelope, defaults to 30 seconds.
+	// Max is the maximum value of the retry period, defaults to 30 seconds.
 	Max time.Duration
 
-	// Multiplier is the factor by which the retry envelope increases.
+	// Multiplier is the factor by which the retry period increases.
 	// It should be greater than 1 and defaults to 2.
 	Multiplier float64
 
-	// cur is the current retry envelope
+	// cur is the current retry period.
 	cur time.Duration
 }
 

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -127,7 +127,7 @@ func ExampleBackoff() {
 	defer cancel()
 
 	resp, err := performHTTPCallWithRetry(ctxWithTimeout, func(ctx context.Context) (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, "some-method", "some-url.com", nil)
+		req, err := http.NewRequestWithContext(ctx, "some-method", "example.com", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -31,13 +31,12 @@ package gax_test
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	gax "github.com/googleapis/gax-go/v2"
 	"google.golang.org/grpc/codes"
 )
-
-const someRPCTimeout = 5 * time.Minute
 
 // Some result that the client might return.
 type fakeResponse struct{}
@@ -83,10 +82,57 @@ func ExampleOnCodes() {
 	// advantage this has is that backoff settings can be changed independently
 	// of the deadline, whereas with a fixed number of retries the deadline
 	// would be a constantly-shifting goalpost.
-	ctxWithTimeout, cancel := context.WithDeadline(ctx, time.Now().Add(someRPCTimeout))
+	ctxWithTimeout, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
 	defer cancel()
 
 	resp, err := performSomeRPCWithRetry(ctxWithTimeout)
+	if err != nil {
+		// TODO: handle err
+	}
+	_ = resp // TODO: use resp if err is nil
+}
+
+func ExampleBackoff() {
+	ctx := context.Background()
+
+	bo := gax.Backoff{
+		Initial:    time.Second,
+		Max:        time.Minute, // Maximum amount of time between retries.
+		Multiplier: 2,
+	}
+
+	performHTTPCallWithRetry := func(ctx context.Context, doHTTPCall func(ctx context.Context) (*http.Response, error)) (*http.Response, error) {
+		for {
+			resp, err := doHTTPCall(ctx)
+			if err != nil {
+				// Retry 503 UNAVAILABLE.
+				if resp.StatusCode == http.StatusServiceUnavailable {
+					if err := gax.Sleep(ctx, bo.Pause()); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				return nil, err
+			}
+			return resp, err
+		}
+	}
+
+	// It's recommended to set deadlines on HTTP calls and around retrying. This
+	// is also usually preferred over setting some fixed number of retries: one
+	// advantage this has is that backoff settings can be changed independently
+	// of the deadline, whereas with a fixed number of retries the deadline
+	// would be a constantly-shifting goalpost.
+	ctxWithTimeout, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+	defer cancel()
+
+	resp, err := performHTTPCallWithRetry(ctxWithTimeout, func(ctx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, "some-method", "some-url.com", nil)
+		if err != nil {
+			return nil, err
+		}
+		return http.DefaultClient.Do(req)
+	})
 	if err != nil {
 		// TODO: handle err
 	}

--- a/v2/gax.go
+++ b/v2/gax.go
@@ -36,4 +36,4 @@
 package gax
 
 // Version specifies the gax-go version being used.
-const Version = "2.0.4"
+const Version = "2.0.5"

--- a/v2/invoke.go
+++ b/v2/invoke.go
@@ -38,8 +38,8 @@ import (
 // APICall is a user defined call stub.
 type APICall func(context.Context, CallSettings) error
 
-// Invoke calls the given APICall,
-// performing retries as specified by opts, if any.
+// Invoke calls the given APICall, performing retries as specified by opts, if
+// any.
 func Invoke(ctx context.Context, call APICall, opts ...CallOption) error {
 	var settings CallSettings
 	for _, opt := range opts {


### PR DESCRIPTION
- Use "retry period" instead of "retry envelope", since period is a well known
  term describing one complete cycle.
- Add note that Backoff does not have a MaxNumRetries/RetryDeadline, which is a
  common question.
- Add example of using Backoff with an HTTP client, since the OnCodes example is
  grpc-specific.