### PR TITLE
v2: don't use http.NewRequestWithContext

### DIFF
--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -127,10 +127,11 @@ func ExampleBackoff() {
 	defer cancel()
 
 	resp, err := performHTTPCallWithRetry(ctxWithTimeout, func(ctx context.Context) (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, "some-method", "example.com", nil)
+		req, err := http.NewRequest("some-method", "example.com", nil)
 		if err != nil {
 			return nil, err
 		}
+		req = req.WithContext(ctx)
 		return http.DefaultClient.Do(req)
 	})
 	if err != nil {


### PR DESCRIPTION
It was added in Go 1.13.

Fixes #99.