### PR TITLE
feat: add OnErrorFunc Retryer

### DIFF
--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -63,12 +63,12 @@ func WithRetry(fn func() Retryer) CallOption {
 	return retryerOption(fn)
 }
 
-// OnPredicate returns a Retryer that retries if and only if the previous attempt
+// OnErrorFunc returns a Retryer that retries if and only if the previous attempt
 // returns an error that satisfies shouldRetry.
 //
 // Pause times between retries are specified by bo. bo is only used for its
 // parameters; each Retryer has its own copy.
-func OnPredicate(bo Backoff, shouldRetry func(err error) bool) Retryer {
+func OnErrorFunc(bo Backoff, shouldRetry func(err error) bool) Retryer {
 	return &predicateRetryer{
 		shouldRetry: shouldRetry,
 		backoff:     bo,

--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -89,7 +89,7 @@ func OnErrors(bo Backoff, compare func(err, target error) bool, errs ...error) R
 //
 // Pause times between retries are specified by bo. bo is only used for its
 // parameters; each Retryer has its own copy.
-func OnError(shouldRetry func(err error) bool, bo Backoff) Retryer {
+func OnError(bo Backoff, shouldRetry func(err error) bool) Retryer {
 	return &errRetryer{
 		shouldRetry: shouldRetry,
 		backoff:     bo,

--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -63,27 +63,6 @@ func WithRetry(fn func() Retryer) CallOption {
 	return retryerOption(fn)
 }
 
-// OnErrors returns a Retryer that retries if and only if the previous attempt
-// returns an error that matches one of the errors listed in errs when compared
-// with the given compare function. Supplying errors.Is (https://pkg.go.dev/errors#Is)
-// for compare is valid.
-//
-// Pause times between retries are specified by bo. bo is only used for its
-// parameters; each Retryer has its own copy.
-func OnErrors(bo Backoff, compare func(err, target error) bool, errs ...error) Retryer {
-	return &errRetryer{
-		backoff: bo,
-		shouldRetry: func(err error) bool {
-			for _, e := range errs {
-				if compare(err, e) {
-					return true
-				}
-			}
-			return false
-		},
-	}
-}
-
 // OnError returns a Retryer that retries if and only if the previous attempt
 // returns an error that satisfies shouldRetry.
 //

--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -69,18 +69,18 @@ func WithRetry(fn func() Retryer) CallOption {
 // Pause times between retries are specified by bo. bo is only used for its
 // parameters; each Retryer has its own copy.
 func OnErrorFunc(bo Backoff, shouldRetry func(err error) bool) Retryer {
-	return &predicateRetryer{
+	return &errorRetryer{
 		shouldRetry: shouldRetry,
 		backoff:     bo,
 	}
 }
 
-type predicateRetryer struct {
+type errorRetryer struct {
 	backoff     Backoff
 	shouldRetry func(err error) bool
 }
 
-func (r *predicateRetryer) Retry(err error) (time.Duration, bool) {
+func (r *errorRetryer) Retry(err error) (time.Duration, bool) {
 	if r.shouldRetry(err) {
 		return r.backoff.Pause(), true
 	}

--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -70,7 +70,7 @@ func WithRetry(fn func() Retryer) CallOption {
 //
 // Pause times between retries are specified by bo. bo is only used for its
 // parameters; each Retryer has its own copy.
-func OnErrors(errs []error, compare func(err, target error) bool, bo Backoff) Retryer {
+func OnErrors(bo Backoff, compare func(err, target error) bool, errs ...error) Retryer {
 	return &errRetryer{
 		backoff: bo,
 		shouldRetry: func(err error) bool {

--- a/v2/call_option.go
+++ b/v2/call_option.go
@@ -63,24 +63,24 @@ func WithRetry(fn func() Retryer) CallOption {
 	return retryerOption(fn)
 }
 
-// OnError returns a Retryer that retries if and only if the previous attempt
+// OnPredicate returns a Retryer that retries if and only if the previous attempt
 // returns an error that satisfies shouldRetry.
 //
 // Pause times between retries are specified by bo. bo is only used for its
 // parameters; each Retryer has its own copy.
-func OnError(bo Backoff, shouldRetry func(err error) bool) Retryer {
-	return &errRetryer{
+func OnPredicate(bo Backoff, shouldRetry func(err error) bool) Retryer {
+	return &predicateRetryer{
 		shouldRetry: shouldRetry,
 		backoff:     bo,
 	}
 }
 
-type errRetryer struct {
+type predicateRetryer struct {
 	backoff     Backoff
 	shouldRetry func(err error) bool
 }
 
-func (r *errRetryer) Retry(err error) (time.Duration, bool) {
+func (r *predicateRetryer) Retry(err error) (time.Duration, bool) {
 	if r.shouldRetry(err) {
 		return r.backoff.Pause(), true
 	}

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -105,7 +105,7 @@ func TestOnErrors(t *testing.T) {
 		{errors.New("This is a retryable error."), []error{errors.New("retryable")}, comp, true},
 	}
 	for _, tst := range tests {
-		b := OnErrors(tst.errs, tst.comp, Backoff{})
+		b := OnErrors(Backoff{}, tst.comp, tst.errs...)
 		if _, retry := b.Retry(tst.e); retry != tst.retry {
 			t.Errorf("retriable errors: %v, error: %s, retry: %t, want %t", tst.errs, tst.e, retry, tst.retry)
 		}

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -102,7 +102,7 @@ func TestOnError(t *testing.T) {
 		{context.DeadlineExceeded, func(err error) bool { return is(err, context.DeadlineExceeded) }, true},
 	}
 	for _, tst := range tests {
-		b := OnError(Backoff{}, tst.shouldRetry)
+		b := OnPredicate(Backoff{}, tst.shouldRetry)
 		if _, retry := b.Retry(tst.e); retry != tst.retry {
 			t.Errorf("retriable func: error: %s, retry: %t, want %t", tst.e, retry, tst.retry)
 		}

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -91,6 +91,10 @@ func TestOnCodes(t *testing.T) {
 }
 
 func TestOnErrors(t *testing.T) {
+	// Use errors.Is if on go 1.13 or higher.
+	is := func(err, target error) bool {
+		return err == target
+	}
 	comp := func(err, target error) bool {
 		return strings.Contains(err.Error(), target.Error())
 	}
@@ -100,8 +104,8 @@ func TestOnErrors(t *testing.T) {
 		comp  func(err, target error) bool
 		retry bool
 	}{
-		{context.DeadlineExceeded, nil, errors.Is, false},
-		{context.DeadlineExceeded, []error{context.DeadlineExceeded}, errors.Is, true},
+		{context.DeadlineExceeded, nil, is, false},
+		{context.DeadlineExceeded, []error{context.DeadlineExceeded}, is, true},
 		{errors.New("This is a retryable error."), []error{errors.New("retryable")}, comp, true},
 	}
 	for _, tst := range tests {
@@ -113,13 +117,17 @@ func TestOnErrors(t *testing.T) {
 }
 
 func TestOnError(t *testing.T) {
+	// Use errors.Is if on go 1.13 or higher.
+	is := func(err, target error) bool {
+		return err == target
+	}
 	tests := []struct {
 		e           error
 		shouldRetry func(err error) bool
 		retry       bool
 	}{
 		{context.DeadlineExceeded, func(err error) bool { return false }, false},
-		{context.DeadlineExceeded, func(err error) bool { return errors.Is(err, context.DeadlineExceeded) }, true},
+		{context.DeadlineExceeded, func(err error) bool { return is(err, context.DeadlineExceeded) }, true},
 	}
 	for _, tst := range tests {
 		b := OnError(tst.shouldRetry, Backoff{})

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -31,8 +31,6 @@ package gax
 
 import (
 	"context"
-	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -86,32 +84,6 @@ func TestOnCodes(t *testing.T) {
 		b := OnCodes(tst.c, Backoff{})
 		if _, retry := b.Retry(apiErr); retry != tst.retry {
 			t.Errorf("retriable codes: %v, error: %s, retry: %t, want %t", tst.c, apiErr, retry, tst.retry)
-		}
-	}
-}
-
-func TestOnErrors(t *testing.T) {
-	// Use errors.Is if on go 1.13 or higher.
-	is := func(err, target error) bool {
-		return err == target
-	}
-	comp := func(err, target error) bool {
-		return strings.Contains(err.Error(), target.Error())
-	}
-	tests := []struct {
-		e     error
-		errs  []error
-		comp  func(err, target error) bool
-		retry bool
-	}{
-		{context.DeadlineExceeded, nil, is, false},
-		{context.DeadlineExceeded, []error{context.DeadlineExceeded}, is, true},
-		{errors.New("this is a retryable error"), []error{errors.New("retryable")}, comp, true},
-	}
-	for _, tst := range tests {
-		b := OnErrors(Backoff{}, tst.comp, tst.errs...)
-		if _, retry := b.Retry(tst.e); retry != tst.retry {
-			t.Errorf("retriable errors: %v, error: %s, retry: %t, want %t", tst.errs, tst.e, retry, tst.retry)
 		}
 	}
 }

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -106,7 +106,7 @@ func TestOnErrors(t *testing.T) {
 	}{
 		{context.DeadlineExceeded, nil, is, false},
 		{context.DeadlineExceeded, []error{context.DeadlineExceeded}, is, true},
-		{errors.New("This is a retryable error."), []error{errors.New("retryable")}, comp, true},
+		{errors.New("this is a retryable error"), []error{errors.New("retryable")}, comp, true},
 	}
 	for _, tst := range tests {
 		b := OnErrors(Backoff{}, tst.comp, tst.errs...)

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -88,7 +88,7 @@ func TestOnCodes(t *testing.T) {
 	}
 }
 
-func TestOnError(t *testing.T) {
+func TestOnErrorFunc(t *testing.T) {
 	// Use errors.Is if on go 1.13 or higher.
 	is := func(err, target error) bool {
 		return err == target
@@ -102,7 +102,7 @@ func TestOnError(t *testing.T) {
 		{context.DeadlineExceeded, func(err error) bool { return is(err, context.DeadlineExceeded) }, true},
 	}
 	for _, tst := range tests {
-		b := OnPredicate(Backoff{}, tst.shouldRetry)
+		b := OnErrorFunc(Backoff{}, tst.shouldRetry)
 		if _, retry := b.Retry(tst.e); retry != tst.retry {
 			t.Errorf("retriable func: error: %s, retry: %t, want %t", tst.e, retry, tst.retry)
 		}

--- a/v2/call_option_test.go
+++ b/v2/call_option_test.go
@@ -130,7 +130,7 @@ func TestOnError(t *testing.T) {
 		{context.DeadlineExceeded, func(err error) bool { return is(err, context.DeadlineExceeded) }, true},
 	}
 	for _, tst := range tests {
-		b := OnError(tst.shouldRetry, Backoff{})
+		b := OnError(Backoff{}, tst.shouldRetry)
 		if _, retry := b.Retry(tst.e); retry != tst.retry {
 			t.Errorf("retriable func: error: %s, retry: %t, want %t", tst.e, retry, tst.retry)
 		}

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -105,12 +105,17 @@ func ExampleOnErrors_sentinel() {
 	ctx := context.Background()
 	c := &fakeClient{}
 
+	// Use errors.Is if on go 1.13 or higher.
+	is := func(err, target error) bool {
+		return err == target
+	}
+
 	myErr := errors.New("This is a retriable error")
 	retryer := gax.OnErrors(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
 		Multiplier: 2,
-	}, errors.Is, myErr)
+	}, is, myErr)
 
 	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
 		for {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -110,7 +110,7 @@ func ExampleOnErrors_sentinel() {
 		return err == target
 	}
 
-	myErr := errors.New("This is a retriable error")
+	myErr := errors.New("this is a retriable error")
 	retryer := gax.OnErrors(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
@@ -160,8 +160,8 @@ func ExampleOnErrors_onCodes() {
 		ts, _ := status.FromError(target)
 		return es.Code() == ts.Code()
 	}
-	unavailableErr := status.Error(codes.Unavailable, "Not available right now, try again.")
-	unknownErr := status.Error(codes.Unknown, "Unknown error, try again.")
+	unavailableErr := status.Error(codes.Unavailable, "not available right now, try again")
+	unknownErr := status.Error(codes.Unknown, "unknown error, try again")
 	retryer := gax.OnErrors(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -31,7 +31,9 @@ package gax_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	gax "github.com/googleapis/gax-go/v2"
@@ -48,6 +50,92 @@ type fakeClient struct{}
 func (c *fakeClient) PerformSomeRPC(ctx context.Context) (*fakeResponse, error) {
 	// An actual client would return something meaningful here.
 	return nil, nil
+}
+
+func ExampleOnErrors_sentinel() {
+	ctx := context.Background()
+	c := &fakeClient{}
+
+	myErr := errors.New("This is a retriable error")
+	retryer := gax.OnErrors([]error{myErr}, errors.Is, gax.Backoff{
+		Initial:    time.Second,
+		Max:        32 * time.Second,
+		Multiplier: 2,
+	})
+
+	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
+		for {
+			resp, err := c.PerformSomeRPC(ctx)
+			if err != nil {
+				if delay, shouldRetry := retryer.Retry(err); shouldRetry {
+					if err := gax.Sleep(ctx, delay); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				return nil, err
+			}
+			return resp, err
+		}
+	}
+
+	// It's recommended to set deadlines on RPCs and around retrying. This is
+	// also usually preferred over setting some fixed number of retries: one
+	// advantage this has is that backoff settings can be changed independently
+	// of the deadline, whereas with a fixed number of retries the deadline
+	// would be a constantly-shifting goalpost.
+	ctxWithTimeout, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+	defer cancel()
+
+	resp, err := performSomeRPCWithRetry(ctxWithTimeout)
+	if err != nil {
+		// TODO: handle err
+	}
+	_ = resp // TODO: use resp if err is nil
+}
+
+func ExampleOnErrors_custom() {
+	ctx := context.Background()
+	c := &fakeClient{}
+
+	compare := func(err, target error) bool {
+		return strings.Contains(err.Error(), target.Error())
+	}
+	retryer := gax.OnErrors([]error{errors.New("error reading from server: EOF")}, compare, gax.Backoff{
+		Initial:    time.Second,
+		Max:        32 * time.Second,
+		Multiplier: 2,
+	})
+
+	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
+		for {
+			resp, err := c.PerformSomeRPC(ctx)
+			if err != nil {
+				if delay, shouldRetry := retryer.Retry(err); shouldRetry {
+					if err := gax.Sleep(ctx, delay); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				return nil, err
+			}
+			return resp, err
+		}
+	}
+
+	// It's recommended to set deadlines on RPCs and around retrying. This is
+	// also usually preferred over setting some fixed number of retries: one
+	// advantage this has is that backoff settings can be changed independently
+	// of the deadline, whereas with a fixed number of retries the deadline
+	// would be a constantly-shifting goalpost.
+	ctxWithTimeout, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+	defer cancel()
+
+	resp, err := performSomeRPCWithRetry(ctxWithTimeout)
+	if err != nil {
+		// TODO: handle err
+	}
+	_ = resp // TODO: use resp if err is nil
 }
 
 func ExampleOnCodes() {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -106,11 +106,11 @@ func ExampleOnErrors_sentinel() {
 	c := &fakeClient{}
 
 	myErr := errors.New("This is a retriable error")
-	retryer := gax.OnErrors([]error{myErr}, errors.Is, gax.Backoff{
+	retryer := gax.OnErrors(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
 		Multiplier: 2,
-	})
+	}, errors.Is, myErr)
 
 	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
 		for {
@@ -155,11 +155,13 @@ func ExampleOnErrors_onCodes() {
 		ts, _ := status.FromError(target)
 		return es.Code() == ts.Code()
 	}
-	retryer := gax.OnErrors([]error{status.Error(codes.Unavailable, "Not available right now, try again.")}, compare, gax.Backoff{
+	unavailableErr := status.Error(codes.Unavailable, "Not available right now, try again.")
+	unknownErr := status.Error(codes.Unknown, "Unknown error, try again.")
+	retryer := gax.OnErrors(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
 		Multiplier: 2,
-	})
+	}, compare, unavailableErr, unknownErr)
 
 	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
 		for {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -51,7 +51,7 @@ func (c *fakeClient) PerformSomeRPC(ctx context.Context) (*fakeResponse, error) 
 	return nil, nil
 }
 
-func ExampleOnError() {
+func ExampleOnPredicate() {
 	ctx := context.Background()
 	c := &fakeClient{}
 
@@ -63,7 +63,7 @@ func ExampleOnError() {
 
 		return st.Code() == codes.Unavailable || st.Code() == codes.Unknown
 	}
-	retryer := gax.OnError(gax.Backoff{
+	retryer := gax.OnPredicate(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
 		Multiplier: 2,

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -52,6 +52,55 @@ func (c *fakeClient) PerformSomeRPC(ctx context.Context) (*fakeResponse, error) 
 	return nil, nil
 }
 
+func ExampleOnError() {
+	ctx := context.Background()
+	c := &fakeClient{}
+
+	shouldRetryUnavailableUnKnown := func(err error) bool {
+		st, ok := status.FromError(err)
+		if !ok {
+			return false
+		}
+
+		return st.Code() == codes.Unavailable || st.Code() == codes.Unknown
+	}
+	retryer := gax.OnError(shouldRetryUnavailableUnKnown, gax.Backoff{
+		Initial:    time.Second,
+		Max:        32 * time.Second,
+		Multiplier: 2,
+	})
+
+	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
+		for {
+			resp, err := c.PerformSomeRPC(ctx)
+			if err != nil {
+				if delay, shouldRetry := retryer.Retry(err); shouldRetry {
+					if err := gax.Sleep(ctx, delay); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				return nil, err
+			}
+			return resp, err
+		}
+	}
+
+	// It's recommended to set deadlines on RPCs and around retrying. This is
+	// also usually preferred over setting some fixed number of retries: one
+	// advantage this has is that backoff settings can be changed independently
+	// of the deadline, whereas with a fixed number of retries the deadline
+	// would be a constantly-shifting goalpost.
+	ctxWithTimeout, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+	defer cancel()
+
+	resp, err := performSomeRPCWithRetry(ctxWithTimeout)
+	if err != nil {
+		// TODO: handle err
+	}
+	_ = resp // TODO: use resp if err is nil
+}
+
 func ExampleOnErrors_sentinel() {
 	ctx := context.Background()
 	c := &fakeClient{}

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -64,11 +64,11 @@ func ExampleOnError() {
 
 		return st.Code() == codes.Unavailable || st.Code() == codes.Unknown
 	}
-	retryer := gax.OnError(shouldRetryUnavailableUnKnown, gax.Backoff{
+	retryer := gax.OnError(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
 		Multiplier: 2,
-	})
+	}, shouldRetryUnavailableUnKnown)
 
 	performSomeRPCWithRetry := func(ctx context.Context) (*fakeResponse, error) {
 		for {

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -51,7 +51,7 @@ func (c *fakeClient) PerformSomeRPC(ctx context.Context) (*fakeResponse, error) 
 	return nil, nil
 }
 
-func ExampleOnPredicate() {
+func ExampleOnErrorFunc() {
 	ctx := context.Background()
 	c := &fakeClient{}
 
@@ -63,7 +63,7 @@ func ExampleOnPredicate() {
 
 		return st.Code() == codes.Unavailable || st.Code() == codes.Unknown
 	}
-	retryer := gax.OnPredicate(gax.Backoff{
+	retryer := gax.OnErrorFunc(gax.Backoff{
 		Initial:    time.Second,
 		Max:        32 * time.Second,
 		Multiplier: 2,


### PR DESCRIPTION
This introduces a new method of creating a `Retryer` designed to evaluate Go `error`s for retry rather than a specific API Call Status type (e.g. grpc `Status`). 

`OnErrorFunc` accepts `shouldRetry func(err error) bool`, which is used to determine if an error given to the `Retryer.Retry` implementation should be retried or not. End users supply `shouldRetry` and have maximum flexibility in what they are testing the `error` for.

For GAPICs, this would mean we could generate default retryers for HTTP Status Codes wrapping error HTTP response in `googleapi.Error` and using `OnErrorFunc` with a `shouldRetry` comparing the `googleapi.Error.Code` to a set of desired codes. 

For some Veneers, it will enable retry of some transient errors wrapped in the normally not-retried `Unknown` status code.

~`OnErrors` accepts `compare func(err, target error) bool` and a variadic set of `error`s to retry against, comparing an `error` given to `Retryer.Retry` against the list of retryable `error`s using `compare`.  `OnErrors` is implemented under the hood using the same `Retryer` `OnError` uses.~

~Note: we don't necessarily need both helper methods. `OnError` would be sufficient, but `OnErrors` follows a similar API as `OnCodes` and I believe it is a simple one to use.~