### PR TITLE
fix(v2/apierror): use errors.As in FromError

### DIFF
--- a/v2/apierror/apierror.go
+++ b/v2/apierror/apierror.go
@@ -32,6 +32,7 @@
 package apierror
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -215,7 +216,8 @@ func FromError(err error) (*APIError, bool) {
 
 	ae := APIError{err: err}
 	st, isStatus := status.FromError(err)
-	herr, isHTTPErr := err.(*googleapi.Error)
+	var herr *googleapi.Error
+	isHTTPErr := errors.As(err, &herr)
 
 	switch {
 	case isStatus:


### PR DESCRIPTION
Now that `v2` is on `go 1.15` we can use `errors`.