### PR TITLE
chore(all): update to 'go 1.17' to enable module graph pruning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,18 @@
 module github.com/googleapis/gax-go
 
-go 1.11
+go 1.17
 
 require (
 	github.com/googleapis/gax-go/v2 v2.4.0
 	google.golang.org/grpc v1.47.0
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
+	golang.org/x/sys v0.0.0-20220502124256-b6088ccd6cba // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/api v0.78.0 // indirect
+	google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/gax-go/v2
 
-go 1.15
+go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.8
@@ -9,4 +9,11 @@ require (
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 
+)
+
+require (
+	github.com/golang/protobuf v1.5.2 // indirect
+	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/text v0.3.7 // indirect
 )


### PR DESCRIPTION
Updating the 'go' directive to 'go 1.17' will enable module graph
pruning (https://go.dev/ref/mod#graph-pruning), which will allow users
who depend on these modules to prune out irrelevant transitive
dependencies.

Note that updating to 'go 1.17' *will not* break existing users on
versions older than 1.17. (The 'go' version is the version required
for full fidelity — in this case, graph pruning — but older versions
of the Go toolchain will continue to make a best-effort attempt to
compile packages and will not report an error if that attempt
succeeds, as it will in this case.)