### PR TITLE
chore: increase renovate maximum supported Go version to 1.19

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
     "ignoreDeps": [],
     "force": {
         "constraints": {
-            "go": "1.17"
+            "go": "1.19"
         }
     }
 }


### PR DESCRIPTION
Intended to unblock #246.