### PR TITLE
feat(v2): add GoVersion package variable

### DIFF
--- a/v2/header.go
+++ b/v2/header.go
@@ -36,38 +36,27 @@ import (
 	"unicode"
 )
 
-// XGoogHeader is for use by the Google Cloud Libraries only.
-//
-// XGoogHeader formats key-value pairs.
-// The resulting string is suitable for x-goog-api-client header.
-func XGoogHeader(keyval ...string) string {
-	if len(keyval) == 0 {
-		return ""
-	}
-	if len(keyval)%2 != 0 {
-		panic("gax.Header: odd argument count")
-	}
-	var buf bytes.Buffer
-	for i := 0; i < len(keyval); i += 2 {
-		buf.WriteByte(' ')
-		buf.WriteString(keyval[i])
-		buf.WriteByte('/')
-		buf.WriteString(keyval[i+1])
-	}
-	return buf.String()[1:]
+var (
+	// GoVersion is a header-safe representation of the current runtime
+	// environment's Go version. This is for GAX consumers that need to
+	// report the Go runtime version in API calls.
+	GoVersion string
+	// version is a package internal global variable for testing purposes.
+	version = runtime.Version
+)
+
+// versionUnknown is only used when the runtime version cannot be determined.
+const versionUnknown = "UNKNOWN"
+
+func init() {
+	GoVersion = goVersion()
 }
 
-// version is a package internal global variable for testing purposes.
-var version = runtime.Version
-
-// VersionUnknown is only used when the runtime version cannot be determined.
-const VersionUnknown = "UNKNOWN"
-
-// GoVersion returns a Go runtime version derived from the runtime environment
+// goVersion returns a Go runtime version derived from the runtime environment
 // that is modified to be suitable for reporting in a header, meaning it has no
 // whitespace. If it is unable to determine the Go runtime version, it returns
-// VersionUnknown.
-func GoVersion() string {
+// versionUnknown.
+func goVersion() string {
 	const develPrefix = "devel +"
 
 	s := version()
@@ -104,4 +93,25 @@ func GoVersion() string {
 		return s
 	}
 	return "UNKNOWN"
+}
+
+// XGoogHeader is for use by the Google Cloud Libraries only.
+//
+// XGoogHeader formats key-value pairs.
+// The resulting string is suitable for x-goog-api-client header.
+func XGoogHeader(keyval ...string) string {
+	if len(keyval) == 0 {
+		return ""
+	}
+	if len(keyval)%2 != 0 {
+		panic("gax.Header: odd argument count")
+	}
+	var buf bytes.Buffer
+	for i := 0; i < len(keyval); i += 2 {
+		buf.WriteByte(' ')
+		buf.WriteString(keyval[i])
+		buf.WriteByte('/')
+		buf.WriteString(keyval[i+1])
+	}
+	return buf.String()[1:]
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -29,7 +29,11 @@
 
 package gax
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestXGoogHeader(t *testing.T) {
 	for _, tst := range []struct {
@@ -43,6 +47,41 @@ func TestXGoogHeader(t *testing.T) {
 		got := XGoogHeader(tst.kv...)
 		if got != tst.want {
 			t.Errorf("Header(%q) = %q, want %q", tst.kv, got, tst.want)
+		}
+	}
+}
+
+func TestGoVersion(t *testing.T) {
+	testVersion := func(v string) func() string {
+		return func() string {
+			return v
+		}
+	}
+	for _, tst := range []struct {
+		v    func() string
+		want string
+	}{
+		{
+			testVersion("go1.19"),
+			"1.19.0",
+		},
+		{
+			testVersion("go1.21-20230317-RC01"),
+			"1.21.0-20230317-RC01",
+		},
+		{
+			testVersion("devel +abc1234"),
+			"abc1234",
+		},
+		{
+			testVersion("this should be unknown"),
+			VersionUnknown,
+		},
+	} {
+		version = tst.v
+		got := GoVersion()
+		if diff := cmp.Diff(got, tst.want); diff != "" {
+			t.Errorf("got(-),want(+):\n%s", diff)
 		}
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -75,11 +75,11 @@ func TestGoVersion(t *testing.T) {
 		},
 		{
 			testVersion("this should be unknown"),
-			VersionUnknown,
+			versionUnknown,
 		},
 	} {
 		version = tst.v
-		got := GoVersion()
+		got := goVersion()
 		if diff := cmp.Diff(got, tst.want); diff != "" {
 			t.Errorf("got(-),want(+):\n%s", diff)
 		}


### PR DESCRIPTION
Adds `GoVersion` package variable that is populated on `init` with an internal `goVersion` method. This `goVersion` method is a copy of the `versionGo` method, which was generated in every GAPIC. Once this is released, we can remove `versionGo` from every GAPIC while migrating all to use this `GoVersion` (https://github.com/googleapis/gapic-generator-go/issues/1299)

Note: The `goVersion` implementation was copied directly from the generated `versionGo` except for one caveat. When the runtime version is a prerelease and already contains a dash `-` separator, we don't need to include another one when concatenating the semver and prerelease strings.