### PR TITLE
feat(v2): add InsertMetadata to header

### DIFF
--- a/v2/header.go
+++ b/v2/header.go
@@ -32,7 +32,6 @@ package gax
 import (
 	"bytes"
 	"context"
-	"net/http"
 	"runtime"
 	"strings"
 	"unicode"
@@ -122,9 +121,9 @@ func XGoogHeader(keyval ...string) string {
 
 // InsertMetadata is for use by the Google Cloud Libraries only.
 //
-// InsertMetadata returns a new context with the provided mds merged with any
+// InsertMetadata returns a new metadata.MD with the provided mds merged with any
 // existing metadata in the provided context.
-func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
+func InsertMetadata(ctx context.Context, mds ...metadata.MD) metadata.MD {
 	out, _ := metadata.FromOutgoingContext(ctx)
 	out = out.Copy()
 	for _, md := range mds {
@@ -132,17 +131,17 @@ func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 			out[k] = append(out[k], v...)
 		}
 	}
-	return metadata.NewOutgoingContext(ctx, out)
+	return out
 }
 
 // BuildHeaders is for use by the Google Cloud Libraries only.
 //
 // BuildHeaders extracts metadata from the outgoing context, joins it with any
-// other given metadata, and converts them into a http.Header.
-func BuildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {
+// other given metadata into a new metadata.MD.
+func BuildHeaders(ctx context.Context, mds ...metadata.MD) metadata.MD {
 	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
 		mds = append(mds, cmd)
 	}
 	md := metadata.Join(mds...)
-	return http.Header(md)
+	return md
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -31,9 +31,12 @@ package gax
 
 import (
 	"bytes"
+	"context"
 	"runtime"
 	"strings"
 	"unicode"
+
+	"google.golang.org/grpc/metadata"
 )
 
 var (
@@ -114,4 +117,19 @@ func XGoogHeader(keyval ...string) string {
 		buf.WriteString(keyval[i+1])
 	}
 	return buf.String()[1:]
+}
+
+// InsertMetadata is for use by the Google Cloud Libraries only.
+//
+// InsertMetadata returns a new context with the provided mds merged with any
+// existing metadata in the provided context.
+func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
+	out, _ := metadata.FromOutgoingContext(ctx)
+	out = out.Copy()
+	for _, md := range mds {
+		for k, v := range md {
+			out[k] = append(out[k], v...)
+		}
+	}
+	return metadata.NewOutgoingContext(ctx, out)
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -32,6 +32,7 @@ package gax
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"runtime"
 	"strings"
 	"unicode"
@@ -132,4 +133,16 @@ func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 		}
 	}
 	return metadata.NewOutgoingContext(ctx, out)
+}
+
+// BuildHeaders is for use by the Google Cloud Libraries only.
+//
+// BuildHeaders extracts metadata from the outgoing context, joins it with any
+// other given metadata, and converts them into a http.Header.
+func BuildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {
+	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
+		mds = append(mds, cmd)
+	}
+	md := metadata.Join(mds...)
+	return http.Header(md)
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -121,27 +121,11 @@ func XGoogHeader(keyval ...string) string {
 
 // InsertMetadata is for use by the Google Cloud Libraries only.
 //
-// InsertMetadata returns a new metadata.MD with the provided mds merged with any
-// existing metadata in the provided context.
+// InsertMetadata returns a new metadata.MD with the provided mds merged with
+// any existing metadata in the provided context.
 func InsertMetadata(ctx context.Context, mds ...metadata.MD) metadata.MD {
-	out, _ := metadata.FromOutgoingContext(ctx)
-	out = out.Copy()
-	for _, md := range mds {
-		for k, v := range md {
-			out[k] = append(out[k], v...)
-		}
+	if ctxMD, ok := metadata.FromOutgoingContext(ctx); ok {
+		mds = append(mds, ctxMD)
 	}
-	return out
-}
-
-// BuildHeaders is for use by the Google Cloud Libraries only.
-//
-// BuildHeaders extracts metadata from the outgoing context, joins it with any
-// other given metadata into a new metadata.MD.
-func BuildHeaders(ctx context.Context, mds ...metadata.MD) metadata.MD {
-	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
-		mds = append(mds, cmd)
-	}
-	md := metadata.Join(mds...)
-	return md
+	return metadata.Join(mds...)
 }

--- a/v2/header_example_test.go
+++ b/v2/header_example_test.go
@@ -1,0 +1,101 @@
+// Copyright 2023, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package gax_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	gax "github.com/googleapis/gax-go/v2"
+	"google.golang.org/grpc/metadata"
+)
+
+func ExampleInsertMetadata_grpcClientWithHeaders() {
+	var c struct {
+		// The x-goog-* metadata to be sent with each request.
+		xGoogMetadata metadata.MD
+	}
+	c.xGoogMetadata = metadata.Pairs("key_1", "val_1")
+	existingMD := metadata.Pairs("key_2", "val_2")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+	md := metadata.Pairs("key_3", "val_3")
+
+	ctx = metadata.NewOutgoingContext(ctx, gax.InsertMetadata(ctx, c.xGoogMetadata, md))
+
+	fmt.Println(metadata.FromOutgoingContext(ctx))
+	// Output: map[key_1:[val_1] key_2:[val_2] key_3:[val_3]] true
+}
+
+func ExampleInsertMetadata_grpcClientWithoutHeaders() {
+	var c struct {
+		// The x-goog-* metadata to be sent with each request.
+		xGoogMetadata metadata.MD
+	}
+	c.xGoogMetadata = metadata.Pairs("key_1", "val_1")
+	existingMD := metadata.Pairs("key_2", "val_2")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+
+	ctx = metadata.NewOutgoingContext(ctx, gax.InsertMetadata(ctx, c.xGoogMetadata))
+
+	fmt.Println(metadata.FromOutgoingContext(ctx))
+	// Output: map[key_1:[val_1] key_2:[val_2]] true
+}
+
+func ExampleInsertMetadata_restClientWithHeaders() {
+	var c struct {
+		// The x-goog-* metadata to be sent with each request.
+		xGoogMetadata metadata.MD
+	}
+	c.xGoogMetadata = metadata.Pairs("key_1", "val_1")
+	existingMD := metadata.Pairs("key_2", "val_2")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+	md := metadata.Pairs("key_3", "val_3")
+
+	headers := http.Header(gax.InsertMetadata(ctx, c.xGoogMetadata, md, metadata.Pairs("Content-Type", "application/json")))
+
+	fmt.Println(headers)
+	// Output: map[content-type:[application/json] key_1:[val_1] key_2:[val_2] key_3:[val_3]]
+}
+
+func ExampleInsertMetadata_restClientWithoutHeaders() {
+	var c struct {
+		// The x-goog-* metadata to be sent with each request.
+		xGoogMetadata metadata.MD
+	}
+	c.xGoogMetadata = metadata.Pairs("key_1", "val_1")
+	existingMD := metadata.Pairs("key_2", "val_2")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+
+	headers := http.Header(gax.InsertMetadata(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json")))
+
+	fmt.Println(headers)
+	// Output: map[content-type:[application/json] key_1:[val_1] key_2:[val_2]]
+}

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -30,9 +30,12 @@
 package gax
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestXGoogHeader(t *testing.T) {
@@ -83,5 +86,22 @@ func TestGoVersion(t *testing.T) {
 		if diff := cmp.Diff(got, tst.want); diff != "" {
 			t.Errorf("got(-),want(+):\n%s", diff)
 		}
+	}
+}
+
+func TestInsertMetadata(t *testing.T) {
+	existingMd := metadata.Pairs("key_1", "val_1")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
+	mds := []metadata.MD{
+		metadata.Pairs("key_2", "val_21"),
+		metadata.Pairs("key_2", "val_22"),
+	}
+
+	ctx2 := InsertMetadata(ctx, mds...)
+
+	got, _ := metadata.FromOutgoingContext(ctx2)
+	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -90,8 +90,8 @@ func TestGoVersion(t *testing.T) {
 }
 
 func TestInsertMetadata(t *testing.T) {
-	existingMd := metadata.Pairs("key_1", "val_1")
-	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
+	existingMD := metadata.Pairs("key_1", "val_1")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
 	mds := []metadata.MD{
 		metadata.Pairs("key_2", "val_21"),
 		metadata.Pairs("key_2", "val_22"),
@@ -102,21 +102,5 @@ func TestInsertMetadata(t *testing.T) {
 	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
-	}
-}
-
-func TestBuildHeaders(t *testing.T) {
-	existingMd := metadata.Pairs("key_1", "val_1")
-	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
-	mds := []metadata.MD{
-		metadata.Pairs("key_2", "val_21"),
-		metadata.Pairs("key_2", "val_22"),
-	}
-
-	got := BuildHeaders(ctx, mds...)
-
-	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", mds, got, want)
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -31,6 +31,7 @@ package gax
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -103,5 +104,21 @@ func TestInsertMetadata(t *testing.T) {
 	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
+	}
+}
+
+func TestBuildHeaders(t *testing.T) {
+	existingMd := metadata.Pairs("key_1", "val_1")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
+	mds := []metadata.MD{
+		metadata.Pairs("key_2", "val_21"),
+		metadata.Pairs("key_2", "val_22"),
+	}
+
+	got := BuildHeaders(ctx, mds...)
+
+	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", mds, got, want)
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -31,7 +31,6 @@ package gax
 
 import (
 	"context"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -98,9 +97,8 @@ func TestInsertMetadata(t *testing.T) {
 		metadata.Pairs("key_2", "val_22"),
 	}
 
-	ctx2 := InsertMetadata(ctx, mds...)
+	got := InsertMetadata(ctx, mds...)
 
-	got, _ := metadata.FromOutgoingContext(ctx2)
 	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
@@ -117,7 +115,7 @@ func TestBuildHeaders(t *testing.T) {
 
 	got := BuildHeaders(ctx, mds...)
 
-	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22"}}
+	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", mds, got, want)
 	}


### PR DESCRIPTION
refs: googleapis/gapic-generator-go#1300
refs: googleapis/gapic-generator-go#1301

This PR normalizes usages of the generated `insertMetadata` and `buildHeaders` functions to a new, relocated `gax.InsertMetadata` function. The new `v2/header_example_test.go` file shows how the new method should be used in the generator.