### PR TITLE
fix(v2): handle space in non-devel go version

### DIFF
--- a/v2/header.go
+++ b/v2/header.go
@@ -66,6 +66,8 @@ func goVersion() string {
 			s = s[:p]
 		}
 		return s
+	} else if p := strings.IndexFunc(s, unicode.IsSpace); p >= 0 {
+		s = s[:p]
 	}
 
 	notSemverRune := func(r rune) bool {

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -77,6 +77,10 @@ func TestGoVersion(t *testing.T) {
 			testVersion("this should be unknown"),
 			versionUnknown,
 		},
+		{
+			testVersion("go1.21-20230101-RC01 cl/1234567 +abc1234"),
+			"1.21.0-20230101-RC01",
+		},
 	} {
 		version = tst.v
 		got := goVersion()


### PR DESCRIPTION
Some development Go runtime versions do not use the `devel +` prefix that `goVersion` already accounted for. To handle this, if it is non-devel (as already defined) and has spaces, we trim everything after the first space, which should be the Go version we want to report.