### PR TITLE
feat(v2): add BuildHeaders and InsertMetadata to header 

### DIFF
--- a/v2/header.go
+++ b/v2/header.go
@@ -131,6 +131,8 @@ func XGoogHeader(keyval ...string) string {
 // provided keyvals metadata pairs with any existing metadata/headers in the
 // provided context. keyvals should have a corresponding value for every key
 // provided. If there is an odd number of keyvals this method will panic.
+// Existing values for keys will not be overwritten, instead provided values
+// will be appended to the list of existing values.
 func InsertMetadataIntoOutgoingContext(ctx context.Context, keyvals ...string) context.Context {
 	return metadata.NewOutgoingContext(ctx, insertMetadata(ctx, keyvals...))
 }
@@ -141,6 +143,8 @@ func InsertMetadataIntoOutgoingContext(ctx context.Context, keyvals ...string) c
 // keyvals header pairs with any existing metadata/headers in the provided
 // context. keyvals should have a corresponding value for every key provided.
 // If there is an odd number of keyvals this method will panic.
+// Existing values for keys will not be overwritten, instead provided values
+// will be appended to the list of existing values.
 func BuildHeaders(ctx context.Context, keyvals ...string) http.Header {
 	return http.Header(insertMetadata(ctx, keyvals...))
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -32,6 +32,7 @@ package gax
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"runtime"
 	"strings"
 	"unicode"
@@ -134,4 +135,16 @@ func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 		}
 	}
 	return metadata.NewOutgoingContext(ctx, out)
+}
+
+// BuildHeaders is for use by the Google Cloud Libraries only.
+//
+// BuildHeaders extracts metadata from the outgoing context, joins it with any
+// other given metadata, and converts them into a http.Header.
+func BuildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {
+	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
+		mds = append(mds, cmd)
+	}
+	md := metadata.Join(mds...)
+	return http.Header(md)
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -32,6 +32,7 @@ package gax
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"runtime"
 	"strings"
@@ -125,15 +126,18 @@ func XGoogHeader(keyval ...string) string {
 // InsertMetadataIntoOutgoingContext is for use by the Google Cloud Libraries
 // only.
 //
-// InsertMetadataIntoOutgoingContext returns a new context with the provided mds
-// merged with any existing metadata in the provided context.
-func InsertMetadataIntoOutgoingContext(ctx context.Context, mds ...metadata.MD) context.Context {
+// InsertMetadataIntoOutgoingContext returns a new context that merges the
+// provided keyvals metadata pairs with any existing metadata in the provided
+// context. keyvals should have a corresponding value for every key provided.
+// If there is an odd number of keyvals this method will panic.
+func InsertMetadataIntoOutgoingContext(ctx context.Context, keyvals ...string) context.Context {
+	if len(keyvals)%2 != 0 {
+		panic(fmt.Sprintf("gax: an even number of key value pairs must be provided, got %d", len(keyvals)))
+	}
 	out, _ := metadata.FromOutgoingContext(ctx)
 	out = out.Copy()
-	for _, md := range mds {
-		for k, v := range md {
-			out[k] = append(out[k], v...)
-		}
+	for i := 0; i < len(keyvals); i = i + 2 {
+		out[keyvals[i]] = append(out[keyvals[i]], keyvals[i+1])
 	}
 	return metadata.NewOutgoingContext(ctx, out)
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -149,8 +149,11 @@ func insertMetadata(ctx context.Context, keyvals ...string) metadata.MD {
 	if len(keyvals)%2 != 0 {
 		panic(fmt.Sprintf("gax: an even number of key value pairs must be provided, got %d", len(keyvals)))
 	}
-	out, _ := metadata.FromOutgoingContext(ctx)
-	out = out.Copy()
+	var out metadata.MD
+	out, ok := metadata.FromOutgoingContext(ctx)
+	if ok {
+		out = out.Copy()
+	}
 	headers := callctx.HeadersFromContext(ctx)
 	for k, v := range headers {
 		out[k] = append(out[k], v...)

--- a/v2/header.go
+++ b/v2/header.go
@@ -122,11 +122,12 @@ func XGoogHeader(keyval ...string) string {
 	return buf.String()[1:]
 }
 
-// InsertMetadata is for use by the Google Cloud Libraries only.
+// InsertMetadataIntoOutgoingContext is for use by the Google Cloud Libraries
+// only.
 //
-// InsertMetadata returns a new context with the provided mds merged with any
-// existing metadata in the provided context.
-func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
+// InsertMetadataIntoOutgoingContext returns a new context with the provided mds
+// merged with any existing metadata in the provided context.
+func InsertMetadataIntoOutgoingContext(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)
 	out = out.Copy()
 	for _, md := range mds {

--- a/v2/header.go
+++ b/v2/header.go
@@ -153,10 +153,9 @@ func insertMetadata(ctx context.Context, keyvals ...string) metadata.MD {
 	if len(keyvals)%2 != 0 {
 		panic(fmt.Sprintf("gax: an even number of key value pairs must be provided, got %d", len(keyvals)))
 	}
-	var out metadata.MD
 	out, ok := metadata.FromOutgoingContext(ctx)
-	if ok {
-		out = out.Copy()
+	if !ok {
+		out = metadata.MD(make(map[string][]string))
 	}
 	headers := callctx.HeadersFromContext(ctx)
 	for k, v := range headers {

--- a/v2/header.go
+++ b/v2/header.go
@@ -31,9 +31,12 @@ package gax
 
 import (
 	"bytes"
+	"context"
 	"runtime"
 	"strings"
 	"unicode"
+
+	"google.golang.org/grpc/metadata"
 )
 
 var (
@@ -116,4 +119,19 @@ func XGoogHeader(keyval ...string) string {
 		buf.WriteString(keyval[i+1])
 	}
 	return buf.String()[1:]
+}
+
+// InsertMetadata is for use by the Google Cloud Libraries only.
+//
+// InsertMetadata returns a new context with the provided mds merged with any
+// existing metadata in the provided context.
+func InsertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
+	out, _ := metadata.FromOutgoingContext(ctx)
+	out = out.Copy()
+	for _, md := range mds {
+		for k, v := range md {
+			out[k] = append(out[k], v...)
+		}
+	}
+	return metadata.NewOutgoingContext(ctx, out)
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -31,6 +31,7 @@ package gax
 
 import (
 	"context"
+	"net/http"
 	"reflect"
 	"testing"
 
@@ -107,5 +108,21 @@ func TestInsertMetadata(t *testing.T) {
 	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
+	}
+}
+
+func TestBuildHeaders(t *testing.T) {
+	existingMd := metadata.Pairs("key_1", "val_1")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
+	mds := []metadata.MD{
+		metadata.Pairs("key_2", "val_21"),
+		metadata.Pairs("key_2", "val_22"),
+	}
+
+	got := BuildHeaders(ctx, mds...)
+
+	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", mds, got, want)
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -32,7 +32,6 @@ package gax
 import (
 	"context"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -108,8 +107,8 @@ func TestInsertMetadataIntoOutgoingContext(t *testing.T) {
 
 	got, _ := metadata.FromOutgoingContext(ctx2)
 	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22", "key_2", "val_23", "key_2", "val_24")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", keyvals, got, want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("InsertMetadata(ctx, %q) mismatch (-want +got):\n%s", keyvals, diff)
 	}
 }
 
@@ -125,7 +124,7 @@ func TestBuildHeaders(t *testing.T) {
 	got := BuildHeaders(ctx, keyvals...)
 
 	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22", "val_23", "val_24"}}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", keyvals, got, want)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("InsertMetadata(ctx, %q) mismatch (-want +got):\n%s", keyvals, diff)
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -30,9 +30,12 @@
 package gax
 
 import (
+	"context"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestXGoogHeader(t *testing.T) {
@@ -87,5 +90,22 @@ func TestGoVersion(t *testing.T) {
 		if diff := cmp.Diff(got, tst.want); diff != "" {
 			t.Errorf("got(-),want(+):\n%s", diff)
 		}
+	}
+}
+
+func TestInsertMetadata(t *testing.T) {
+	existingMd := metadata.Pairs("key_1", "val_1")
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
+	mds := []metadata.MD{
+		metadata.Pairs("key_2", "val_21"),
+		metadata.Pairs("key_2", "val_22"),
+	}
+
+	ctx2 := InsertMetadata(ctx, mds...)
+
+	got, _ := metadata.FromOutgoingContext(ctx2)
+	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
 	}
 }

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -95,19 +95,16 @@ func TestGoVersion(t *testing.T) {
 }
 
 func TestInsertMetadataIntoOutgoingContext(t *testing.T) {
-	existingMd := metadata.Pairs("key_1", "val_1")
+	existingMd := metadata.Pairs("key_1", "val_1", "key_2", "val_21")
 	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
-	mds := []metadata.MD{
-		metadata.Pairs("key_2", "val_21"),
-		metadata.Pairs("key_2", "val_22"),
-	}
+	keyvals := []string{"key_2", "val_22", "key_2", "val_23"}
 
-	ctx2 := InsertMetadataIntoOutgoingContext(ctx, mds...)
+	ctx2 := InsertMetadataIntoOutgoingContext(ctx, keyvals...)
 
 	got, _ := metadata.FromOutgoingContext(ctx2)
-	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")
+	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22", "key_2", "val_23")
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", mds, got, want)
+		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", keyvals, got, want)
 	}
 }
 

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/gax-go/v2/callctx"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -95,27 +96,35 @@ func TestGoVersion(t *testing.T) {
 }
 
 func TestInsertMetadataIntoOutgoingContext(t *testing.T) {
+	// User-provided metadata set in context
 	existingMd := metadata.Pairs("key_1", "val_1", "key_2", "val_21")
 	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
-	keyvals := []string{"key_2", "val_22", "key_2", "val_23"}
+	// User-provided headers set in context
+	ctx = callctx.SetHeaders(ctx, "key_2", "val_22")
+	// Client-provided headers
+	keyvals := []string{"key_2", "val_23", "key_2", "val_24"}
 
 	ctx2 := InsertMetadataIntoOutgoingContext(ctx, keyvals...)
 
 	got, _ := metadata.FromOutgoingContext(ctx2)
-	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22", "key_2", "val_23")
+	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22", "key_2", "val_23", "key_2", "val_24")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("InsertMetadata(ctx, %q) = %q, want %q", keyvals, got, want)
 	}
 }
 
 func TestBuildHeaders(t *testing.T) {
+	// User-provided metadata set in context
 	existingMd := metadata.Pairs("key_1", "val_1", "key_2", "val_21")
 	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
-	keyvals := []string{"key_2", "val_22", "key_2", "val_23"}
+	// User-provided headers set in context
+	ctx = callctx.SetHeaders(ctx, "key_2", "val_22")
+	// Client-provided headers
+	keyvals := []string{"key_2", "val_23", "key_2", "val_24"}
 
 	got := BuildHeaders(ctx, keyvals...)
 
-	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22", "val_23"}}
+	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22", "val_23", "val_24"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", keyvals, got, want)
 	}

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -105,12 +105,12 @@ func TestInsertMetadataIntoOutgoingContext(t *testing.T) {
 		want          metadata.MD
 	}{
 		{
-			userMd:        metadata.Pairs("key_1", "val_1", "key_2", "val_21"),
-			want:          metadata.Pairs("key_1", "val_1", "key_2", "val_21"),
+			userMd: metadata.Pairs("key_1", "val_1", "key_2", "val_21"),
+			want:   metadata.Pairs("key_1", "val_1", "key_2", "val_21"),
 		},
 		{
-			userHeaders:   []string{"key_2", "val_22"},
-			want:          metadata.Pairs("key_2", "val_22"),
+			userHeaders: []string{"key_2", "val_22"},
+			want:        metadata.Pairs("key_2", "val_22"),
 		},
 		{
 			clientHeaders: []string{"key_2", "val_23", "key_2", "val_24"},

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -94,7 +94,7 @@ func TestGoVersion(t *testing.T) {
 	}
 }
 
-func TestInsertMetadata(t *testing.T) {
+func TestInsertMetadataIntoOutgoingContext(t *testing.T) {
 	existingMd := metadata.Pairs("key_1", "val_1")
 	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
 	mds := []metadata.MD{
@@ -102,7 +102,7 @@ func TestInsertMetadata(t *testing.T) {
 		metadata.Pairs("key_2", "val_22"),
 	}
 
-	ctx2 := InsertMetadata(ctx, mds...)
+	ctx2 := InsertMetadataIntoOutgoingContext(ctx, mds...)
 
 	got, _ := metadata.FromOutgoingContext(ctx2)
 	want := metadata.Pairs("key_1", "val_1", "key_2", "val_21", "key_2", "val_22")

--- a/v2/header_test.go
+++ b/v2/header_test.go
@@ -109,17 +109,14 @@ func TestInsertMetadataIntoOutgoingContext(t *testing.T) {
 }
 
 func TestBuildHeaders(t *testing.T) {
-	existingMd := metadata.Pairs("key_1", "val_1")
+	existingMd := metadata.Pairs("key_1", "val_1", "key_2", "val_21")
 	ctx := metadata.NewOutgoingContext(context.Background(), existingMd)
-	mds := []metadata.MD{
-		metadata.Pairs("key_2", "val_21"),
-		metadata.Pairs("key_2", "val_22"),
-	}
+	keyvals := []string{"key_2", "val_22", "key_2", "val_23"}
 
-	got := BuildHeaders(ctx, mds...)
+	got := BuildHeaders(ctx, keyvals...)
 
-	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22"}}
+	want := http.Header{"key_1": []string{"val_1"}, "key_2": []string{"val_21", "val_22", "val_23"}}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", mds, got, want)
+		t.Errorf("BuildHeaders(ctx, %q) = %q, want %q", keyvals, got, want)
 	}
 }


### PR DESCRIPTION
replaces: #286

refs: https://github.com/googleapis/gapic-generator-go/issues/1300
refs: https://github.com/googleapis/gapic-generator-go/issues/1301

This PR moves the generated `insertMetadata` and `buildHeaders` functions to new, relocated gax header functions.