### PR TITLE
feat(v2/callctx): add new callctx package

### DIFF
--- a/v2/callctx/callctx.go
+++ b/v2/callctx/callctx.go
@@ -34,6 +34,7 @@ package callctx
 
 import (
 	"context"
+	"fmt"
 )
 
 const (
@@ -57,12 +58,10 @@ func HeadersFromContext(ctx context.Context) map[string][]string {
 // be retrieved by [HeadersFromContext]. Values stored in this manner will
 // automatically be retrieved by client libraries and sent as outgoing headers
 // on all requests. keyvals should have a corresponding value for every key
-// provided. If there is an odd number of keyvals the context passed to this
-// method will be returned and no values will be stored in the context.
+// provided. If there is an odd number of keyvals this method will panic.
 func SetHeaders(ctx context.Context, keyvals ...string) context.Context {
 	if len(keyvals)%2 != 0 {
-		// TODO(codyoss): maybe eventually log here when we have the facilities
-		return ctx
+		panic(fmt.Sprintf("callctx: an even number of key value pairs must be proviced, got %d", len(keyvals)))
 	}
 	h, ok := ctx.Value(headerKey).(map[string][]string)
 	if !ok {

--- a/v2/callctx/callctx.go
+++ b/v2/callctx/callctx.go
@@ -61,7 +61,7 @@ func HeadersFromContext(ctx context.Context) map[string][]string {
 // provided. If there is an odd number of keyvals this method will panic.
 func SetHeaders(ctx context.Context, keyvals ...string) context.Context {
 	if len(keyvals)%2 != 0 {
-		panic(fmt.Sprintf("callctx: an even number of key value pairs must be proviced, got %d", len(keyvals)))
+		panic(fmt.Sprintf("callctx: an even number of key value pairs must be provided, got %d", len(keyvals)))
 	}
 	h, ok := ctx.Value(headerKey).(map[string][]string)
 	if !ok {

--- a/v2/callctx/callctx.go
+++ b/v2/callctx/callctx.go
@@ -1,0 +1,75 @@
+// Copyright 2023, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// Package callctx provides helpers for storing and retrieving values out of
+// [context.Context]. These values are used by our client libraries in various
+// ways across the stack.
+package callctx
+
+import (
+	"context"
+)
+
+const (
+	headerKey = contextKey("header")
+)
+
+// contextKey is a private type used to store/retrieve context values.
+type contextKey string
+
+// HeadersFromContext retrieves headers set from [SetHeaders]. These headers
+// can then be cast to http.Header or metadata.MD to send along on requests.
+func HeadersFromContext(ctx context.Context) map[string][]string {
+	m, ok := ctx.Value(headerKey).(map[string][]string)
+	if !ok {
+		return nil
+	}
+	return m
+}
+
+// SetHeaders stores key value pairs in the returned context that can later
+// be retrieved by [HeadersFromContext]. Values stored in this manner will
+// automatically be retrieved by client libraries and sent as outgoing headers
+// on all requests. keyvals should have a corresponding value for every key
+// provided. If there is an odd number of keyvals the context passed to this
+// method will be returned and no values will be stored in the context.
+func SetHeaders(ctx context.Context, keyvals ...string) context.Context {
+	if len(keyvals)%2 != 0 {
+		// TODO(codyoss): maybe eventually log here when we have the facilities
+		return ctx
+	}
+	h, ok := ctx.Value(headerKey).(map[string][]string)
+	if !ok {
+		h = make(map[string][]string)
+	}
+	for i := 0; i < len(keyvals); i = i + 2 {
+		h[keyvals[i]] = append(h[keyvals[i]], keyvals[i+1])
+	}
+	return context.WithValue(ctx, headerKey, h)
+}

--- a/v2/callctx/callctx_example_test.go
+++ b/v2/callctx/callctx_example_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package callctx_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/googleapis/gax-go/v2/callctx"
+)
+
+func ExampleSetHeaders() {
+	ctx := context.Background()
+	ctx = callctx.SetHeaders(ctx, "key", "value")
+
+	// Send the returned context to the request you are making. Later on these
+	// values will be retrieved and set on outgoing requests.
+
+	headers := callctx.HeadersFromContext(ctx)
+	fmt.Println(headers["key"][0])
+	// Output: value
+}

--- a/v2/callctx/callctx_test.go
+++ b/v2/callctx/callctx_test.go
@@ -57,11 +57,6 @@ func TestAll(t *testing.T) {
 			pairs: []string{"key", "value", "key", "value2"},
 			want:  map[string][]string{"key": {"value", "value2"}},
 		},
-		{
-			name:  "odd key value pairs",
-			pairs: []string{"key", "value", "key"},
-			want:  nil,
-		},
 	}
 	for _, tc := range testCases {
 		ctx := context.Background()
@@ -71,4 +66,14 @@ func TestAll(t *testing.T) {
 			t.Errorf("HeadersFromContext() mismatch (-want +got):\n%s", diff)
 		}
 	}
+}
+
+func TestSetHeaders_panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic with odd key value pairs")
+		}
+	}()
+	ctx := context.Background()
+	SetHeaders(ctx, "1", "2", "3")
 }

--- a/v2/callctx/callctx_test.go
+++ b/v2/callctx/callctx_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package callctx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAll(t *testing.T) {
+	testCases := []struct {
+		name  string
+		pairs []string
+		want  map[string][]string
+	}{
+		{
+			name:  "standard",
+			pairs: []string{"key", "value"},
+			want:  map[string][]string{"key": {"value"}},
+		},
+		{
+			name:  "multiple values",
+			pairs: []string{"key", "value", "key2", "value2"},
+			want:  map[string][]string{"key": {"value"}, "key2": {"value2"}},
+		},
+		{
+			name:  "multiple values with same key",
+			pairs: []string{"key", "value", "key", "value2"},
+			want:  map[string][]string{"key": {"value", "value2"}},
+		},
+		{
+			name:  "odd key value pairs",
+			pairs: []string{"key", "value", "key"},
+			want:  nil,
+		},
+	}
+	for _, tc := range testCases {
+		ctx := context.Background()
+		ctx = SetHeaders(ctx, tc.pairs...)
+		got := HeadersFromContext(ctx)
+		if diff := cmp.Diff(tc.want, got); diff != "" {
+			t.Errorf("HeadersFromContext() mismatch (-want +got):\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
Add a new callctx package to gax to facilitate adding and retrieving values from context.Context that our libraries can use to share information throughout the call stack. The first addition to this package will be two APIs to allow users to set RPC headers that will be added to API requests our clients make.

A follow up PR will be made to add using these after these changes are merged with #290.