### PR TITLE
chore(deps): temporarily ignore grpc dep

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,9 @@
     "commitMessageAction": "update",
     "labels": ["automerge"],
     "groupName": "all",
-    "ignoreDeps": [],
+    "ignoreDeps": [
+        "google.golang.org/grpc"
+    ],
     "force": {
         "constraints": {
             "go": "1.19"


### PR DESCRIPTION
Temporarily ignore the grpc-go dep until we can increase the floor Go version to Go 1.19: #300 