### PR TITLE
fix: add XGoogFieldMask constant

### DIFF
--- a/v2/callctx/callctx.go
+++ b/v2/callctx/callctx.go
@@ -38,6 +38,14 @@ import (
 )
 
 const (
+	// XGoogFieldMask is the canonical header key for the [System Parameter]
+	// that specifies the response read mask. The value(s) for this header
+	// must adhere to format described in [fieldmaskpb].
+	//
+	// [System Parameter]: https://cloud.google.com/apis/docs/system-parameters
+	// [fieldmaskpb]: https://google.golang.org/protobuf/types/known/fieldmaskpb
+	XGoogFieldMask = "x-goog-fieldmask"
+
 	headerKey = contextKey("header")
 )
 

--- a/v2/callctx/callctx.go
+++ b/v2/callctx/callctx.go
@@ -38,13 +38,13 @@ import (
 )
 
 const (
-	// XGoogFieldMask is the canonical header key for the [System Parameter]
+	// XGoogFieldMaskHeader is the canonical header key for the [System Parameter]
 	// that specifies the response read mask. The value(s) for this header
 	// must adhere to format described in [fieldmaskpb].
 	//
 	// [System Parameter]: https://cloud.google.com/apis/docs/system-parameters
 	// [fieldmaskpb]: https://google.golang.org/protobuf/types/known/fieldmaskpb
-	XGoogFieldMask = "x-goog-fieldmask"
+	XGoogFieldMaskHeader = "x-goog-fieldmask"
 
 	headerKey = contextKey("header")
 )

--- a/v2/callctx/callctx_example_test.go
+++ b/v2/callctx/callctx_example_test.go
@@ -52,7 +52,7 @@ func ExampleSetHeaders() {
 
 func ExampleXGoogFieldMask() {
 	ctx := context.Background()
-	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, "value")
+	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, "field_one", "field.two")
 
 	// Send the returned context to the request you are making.
 }

--- a/v2/callctx/callctx_example_test.go
+++ b/v2/callctx/callctx_example_test.go
@@ -50,14 +50,14 @@ func ExampleSetHeaders() {
 	// Output: value
 }
 
-func ExampleXGoogFieldMask() {
+func ExampleXGoogFieldMaskHeader() {
 	ctx := context.Background()
-	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, "field_one,field.two")
+	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMaskHeader, "field_one,field.two")
 
 	// Send the returned context to the request you are making.
 }
 
-func ExampleXGoogFieldMask_fieldmaskpb() {
+func ExampleXGoogFieldMaskHeader_fieldmaskpb() {
 	// Build a mask using the expected response protobuf message.
 	mask, err := fieldmaskpb.New(&metric.MetricDescriptor{}, "display_name", "metadata.launch_stage")
 	if err != nil {
@@ -65,7 +65,7 @@ func ExampleXGoogFieldMask_fieldmaskpb() {
 	}
 
 	ctx := context.Background()
-	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, mask.String())
+	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMaskHeader, mask.String())
 
 	// Send the returned context to the request you are making.
 }

--- a/v2/callctx/callctx_example_test.go
+++ b/v2/callctx/callctx_example_test.go
@@ -52,7 +52,7 @@ func ExampleSetHeaders() {
 
 func ExampleXGoogFieldMask() {
 	ctx := context.Background()
-	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, "field_one", "field.two")
+	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, "field_one,field.two")
 
 	// Send the returned context to the request you are making.
 }

--- a/v2/callctx/callctx_example_test.go
+++ b/v2/callctx/callctx_example_test.go
@@ -34,6 +34,8 @@ import (
 	"fmt"
 
 	"github.com/googleapis/gax-go/v2/callctx"
+	"google.golang.org/genproto/googleapis/api/metric"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 func ExampleSetHeaders() {
@@ -46,4 +48,24 @@ func ExampleSetHeaders() {
 	headers := callctx.HeadersFromContext(ctx)
 	fmt.Println(headers["key"][0])
 	// Output: value
+}
+
+func ExampleXGoogFieldMask() {
+	ctx := context.Background()
+	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, "value")
+
+	// Send the returned context to the request you are making.
+}
+
+func ExampleXGoogFieldMask_fieldmaskpb() {
+	// Build a mask using the expected response protobuf message.
+	mask, err := fieldmaskpb.New(&metric.MetricDescriptor{}, "display_name", "metadata.launch_stage")
+	if err != nil {
+		// handle error
+	}
+
+	ctx := context.Background()
+	ctx = callctx.SetHeaders(ctx, callctx.XGoogFieldMask, mask.String())
+
+	// Send the returned context to the request you are making.
 }

--- a/v2/header.go
+++ b/v2/header.go
@@ -103,7 +103,9 @@ func goVersion() string {
 	return "UNKNOWN"
 }
 
-// XGoogHeader is for use by the Google Cloud Libraries only.
+// XGoogHeader is for use by the Google Cloud Libraries only. See package
+// [github.com/googleapis/gax-go/v2/callctx] for help setting/retrieving
+// request/response headers.
 //
 // XGoogHeader formats key-value pairs.
 // The resulting string is suitable for x-goog-api-client header.
@@ -125,7 +127,8 @@ func XGoogHeader(keyval ...string) string {
 }
 
 // InsertMetadataIntoOutgoingContext is for use by the Google Cloud Libraries
-// only.
+// only. See package [github.com/googleapis/gax-go/v2/callctx] for help
+// setting/retrieving request/response headers.
 //
 // InsertMetadataIntoOutgoingContext returns a new context that merges the
 // provided keyvals metadata pairs with any existing metadata/headers in the
@@ -137,7 +140,9 @@ func InsertMetadataIntoOutgoingContext(ctx context.Context, keyvals ...string) c
 	return metadata.NewOutgoingContext(ctx, insertMetadata(ctx, keyvals...))
 }
 
-// BuildHeaders is for use by the Google Cloud Libraries only.
+// BuildHeaders is for use by the Google Cloud Libraries only. See package
+// [github.com/googleapis/gax-go/v2/callctx] for help setting/retrieving
+// request/response headers.
 //
 // BuildHeaders returns a new http.Header that merges the provided
 // keyvals header pairs with any existing metadata/headers in the provided


### PR DESCRIPTION
Adds `XGoogFieldMask` constant for use with `SetHeaders` to supply the Google API system parameter.

Include documentation "redirect" to `callctx` for `BuildHeaders` and other internal header related helpers in the top level package.

Add example snippets for `XGoogFieldMask`.

Fixes #320 - we will only do this constant for now.