### PR TITLE
fix(v2/callctx): fix SetHeader race by cloning header map

### DIFF
--- a/v2/callctx/callctx.go
+++ b/v2/callctx/callctx.go
@@ -74,9 +74,25 @@ func SetHeaders(ctx context.Context, keyvals ...string) context.Context {
 	h, ok := ctx.Value(headerKey).(map[string][]string)
 	if !ok {
 		h = make(map[string][]string)
+	} else {
+		h = cloneHeaders(h)
 	}
+
 	for i := 0; i < len(keyvals); i = i + 2 {
 		h[keyvals[i]] = append(h[keyvals[i]], keyvals[i+1])
 	}
 	return context.WithValue(ctx, headerKey, h)
+}
+
+// cloneHeaders makes a new key-value map while reusing the value slices.
+// As such, new values should be appended to the value slice, and modifying
+// indexed values is not thread safe.
+//
+// TODO: Replace this with maps.Clone when Go 1.21 is the minimum version.
+func cloneHeaders(h map[string][]string) map[string][]string {
+	c := make(map[string][]string, len(h))
+	for k, v := range h {
+		c[k] = v
+	}
+	return c
 }


### PR DESCRIPTION
Clone any existing header map instead of reusing it directly to avoid a data race when the same context is reused multiple times each with a call to `SetHeaders` with the same header key.

Updates #325 