### PR TITLE
chore: migrate repository (v2 only) to Librarian

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,5 +1,0 @@
-handleGHRelease: true
-manifest: true
-manifestFile: v2/.release-please-manifest.json
-manifestConfig: v2/release-please-config.json
-releaseType: go-yoshi

--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,2 +1,0 @@
-enabled: true
-multiScmName: gax-go

--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -1,0 +1,8 @@
+# Hand-maintained configuration for libraries.
+#
+# All libraries with handwritten code (core, hybrid and handwritten)
+# libraries have "release_blocked: true" so that releases are
+# explicitly initiated
+libraries:
+  - id: "v2"
+    release_blocked: true

--- a/.librarian/generator-input/repo-config.yaml
+++ b/.librarian/generator-input/repo-config.yaml
@@ -1,0 +1,1 @@
+# No config required

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,0 +1,7 @@
+image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
+libraries:
+  - id: v2
+    version: 2.15.0
+    source_roots:
+      - 'v2'
+    tag_format: 'v{version}'


### PR DESCRIPTION
Towards https://github.com/googleapis/librarian/issues/2417

https://github.com/jskeet/gax-go/pull/2 shows a sample release PR.