### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @googleapis/yoshi-go-admins @googleapis/actools-go
+* @googleapis/cloud-sdk-go-eng


### PR DESCRIPTION
swap cloud-sdk-go-eng for yoshi-go-admins, remove actools-go as a legacy owner