### PR TITLE
feat(v2): add http.response.status_code to TransportTelemetryData

### DIFF
--- a/v2/telemetry.go
+++ b/v2/telemetry.go
@@ -54,8 +54,9 @@ import (
 // regardless of any other documented package stability guarantees.
 // It should not be used by external consumers.
 type TransportTelemetryData struct {
-	serverAddress string
-	serverPort    int
+	serverAddress  string
+	serverPort     int
+	httpStatusCode int
 }
 
 // SetServerAddress sets the server address.
@@ -77,6 +78,16 @@ func (d *TransportTelemetryData) SetServerPort(port int) { d.serverPort = port }
 // Experimental: This function is experimental and may be modified or removed in future versions,
 // regardless of any other documented package stability guarantees.
 func (d *TransportTelemetryData) ServerPort() int { return d.serverPort }
+
+// SetHTTPStatusCode sets the HTTP status code.
+// Experimental: This function is experimental and may be modified or removed in future versions,
+// regardless of any other documented package stability guarantees.
+func (d *TransportTelemetryData) SetHTTPStatusCode(code int) { d.httpStatusCode = code }
+
+// HTTPStatusCode returns the HTTP status code.
+// Experimental: This function is experimental and may be modified or removed in future versions,
+// regardless of any other documented package stability guarantees.
+func (d *TransportTelemetryData) HTTPStatusCode() int { return d.httpStatusCode }
 
 // transportTelemetryKey is the private context key used to inject TransportTelemetryData
 type transportTelemetryKey struct{}
@@ -449,6 +460,9 @@ func recordMetric(ctx context.Context, settings CallSettings, d time.Duration, e
 		}
 		if td.ServerPort() != 0 {
 			attrs = append(attrs, attribute.Int("server.port", td.ServerPort()))
+		}
+		if td.HTTPStatusCode() != 0 {
+			attrs = append(attrs, attribute.Int("http.response.status_code", td.HTTPStatusCode()))
 		}
 	}
 

--- a/v2/telemetry_test.go
+++ b/v2/telemetry_test.go
@@ -177,7 +177,7 @@ func TestNewClientMetrics(t *testing.T) {
 			// Verify Exact Scope Attributes
 			scopeAttrs := make(map[string]string)
 			for _, set := range sm.Scope.Attributes.ToSlice() {
-				scopeAttrs[string(set.Key)] = set.Value.AsString()
+				scopeAttrs[string(set.Key)] = set.Value.String()
 			}
 
 			if diff := cmp.Diff(tt.wantScopeAttr, scopeAttrs); diff != "" {
@@ -196,7 +196,7 @@ func TestNewClientMetrics(t *testing.T) {
 
 			dpAttrs := make(map[string]string)
 			for _, set := range dp.Attributes.ToSlice() {
-				dpAttrs[string(set.Key)] = set.Value.AsString()
+				dpAttrs[string(set.Key)] = set.Value.String()
 			}
 
 			if diff := cmp.Diff(tt.wantDataAttr, dpAttrs); diff != "" {
@@ -318,6 +318,7 @@ func TestTransportTelemetry(t *testing.T) {
 	data := &TransportTelemetryData{}
 	data.SetServerAddress("localhost")
 	data.SetServerPort(8080)
+	data.SetHTTPStatusCode(200)
 
 	ctx = InjectTransportTelemetry(ctx, data)
 	got := ExtractTransportTelemetry(ctx)
@@ -332,6 +333,9 @@ func TestTransportTelemetry(t *testing.T) {
 	}
 	if got.ServerPort() != 8080 {
 		t.Errorf("got.ServerPort() = %d, want %d", got.ServerPort(), 8080)
+	}
+	if got.HTTPStatusCode() != 200 {
+		t.Errorf("got.HTTPStatusCode() = %d, want %d", got.HTTPStatusCode(), 200)
 	}
 }
 
@@ -449,13 +453,15 @@ func TestExtractTelemetryErrorInfo(t *testing.T) {
 
 func TestRecordMetric(t *testing.T) {
 	tests := []struct {
-		name         string
-		method       string
-		template     string
-		err          error
-		wantSum      float64
-		wantDataAttr map[string]string
-		nilMetrics   bool
+		name          string
+		method        string
+		template      string
+		err           error
+		wantSum       float64
+		wantDataAttr  map[string]string
+		nilMetrics    bool
+		transportData *TransportTelemetryData
+		rpcSystem     string
 	}{
 		{
 			name:       "nil_metrics",
@@ -490,6 +496,29 @@ func TestRecordMetric(t *testing.T) {
 				"url.template":             "/v1/test/{id}",
 			},
 		},
+		{
+			name:      "http_success_with_status_code",
+			method:    "my.service.Method",
+			template:  "/v1/test/{id}",
+			err:       nil,
+			wantSum:   1.5,
+			rpcSystem: "http",
+			transportData: &TransportTelemetryData{
+				serverAddress:  "localhost",
+				serverPort:     8080,
+				httpStatusCode: 200,
+			},
+			wantDataAttr: map[string]string{
+				"url.domain":                "test.domain",
+				"rpc.system.name":           "http",
+				"rpc.response.status_code":  "OK",
+				"rpc.method":                "my.service.Method",
+				"url.template":              "/v1/test/{id}",
+				"server.address":            "localhost",
+				"server.port":               "8080",
+				"http.response.status_code": "200",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -502,19 +531,26 @@ func TestRecordMetric(t *testing.T) {
 			if tt.template != "" {
 				ctx = callctx.WithTelemetryContext(ctx, "url_template", tt.template)
 			}
+			if tt.transportData != nil {
+				ctx = InjectTransportTelemetry(ctx, tt.transportData)
+			}
 
 			reader := sdkmetric.NewManualReader()
 			provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
 
 			settings := CallSettings{}
 			if !tt.nilMetrics {
+				rpcSys := "grpc"
+				if tt.rpcSystem != "" {
+					rpcSys = tt.rpcSystem
+				}
 				opts := []TelemetryOption{
 					WithMeterProvider(provider),
 					WithTelemetryAttributes(map[string]string{
 						ClientArtifact: "test-artifact",
 						ClientService:  "test-service",
 						URLDomain:      "test.domain",
-						RPCSystem:      "grpc",
+						RPCSystem:      rpcSys,
 					}),
 				}
 				cm := NewClientMetrics(opts...)
@@ -582,7 +618,7 @@ func TestRecordMetric(t *testing.T) {
 
 			gotDataAttr := make(map[string]string)
 			for _, a := range point.Attributes.ToSlice() {
-				gotDataAttr[string(a.Key)] = a.Value.AsString()
+				gotDataAttr[string(a.Key)] = a.Value.String()
 			}
 
 			if diff := cmp.Diff(tt.wantDataAttr, gotDataAttr); diff != "" {


### PR DESCRIPTION
When configuring Google Cloud Go clients to use the REST/HTTP transport, the emitted gcp.client.request.duration metric successfully records the mapped rpc.response.status_code (e.g., "OK", "NOT_FOUND") but fails to record the raw numeric http.response.status_code dimension (e.g., 200, 404) required by the metrics specification. 

This occurs because TransportTelemetryData —the container used to pass transport-specific telemetry back to the transport-agnostic gax layer—only supported server.address and server.port, leaving no way for the HTTP transport to communicate the status code back to gax.recordMetric.

Added the httpStatusCode field along with SetHTTPStatusCode(int) and HTTPStatusCode() methods to allow transport layers to report the HTTP status code.
Updated recordMetric in telemetry.go to check for a non-zero HTTP status code in TransportTelemetryData and append it as the http.response.status_code integer attribute on the gcp.client.request.duration metric.

*Note: This PR provides the necessary capability in gax-go. A companion PR in google-cloud-go https://github.com/googleapis/google-cloud-go/pull/20053 will update the HTTP transport (otelAttributeTransport) to actually populate this status code.*

Bug: b/499375444