### PR TITLE
chore: limit go version updates via constraint strictness

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,12 @@
         "constraints": {
             "go": "1.25"
         }
-    }
+    },
+    "packageRules": [
+      {
+        "description": "prevent go version upgrades",
+        "matchManagers": ["gomod"],
+        "constraintsFiltering": "strict"
+      }
+    ]
 }


### PR DESCRIPTION
https://docs.renovatebot.com/modules/manager/gomod/#only-suggesting-updates-that-match-your-go-directive